### PR TITLE
Se ha probado con éxito en Ubuntu Server 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This playbook download, compile and install git from its latest version.
 
 Tested on:
 
--Centos 6.5
+-Centos 6.5 and 
 
 -Debian Wheezy
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This playbook download, compile and install git from its latest version.
 
 Tested on:
 
--Centos 6.5 and 
+-Centos 6.5 and 7.6
 
 -Debian Wheezy
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Tested on:
 -Centos 6.5
 
 -Debian Wheezy
+
+-Ubuntu server 19.04

--- a/roles/common/tasks/prerequisites-debian.yml
+++ b/roles/common/tasks/prerequisites-debian.yml
@@ -1,18 +1,17 @@
 ---
 
 - name: Installing Debian family dependencies
-  apt: name={{ item }} state=present update_cache=yes
-  with_items:
-      - build-essential
-      - zlib1g-dev
-      - libextutils-cbuilder-perl
-      - libmodule-install-perl
-      - gettext
-      - asciidoc 
-      - xmlto 
-      - wget
-      - unzip
-      - make
-      - autoconf
-      - gcc 
- 
+  apt:
+      name:
+        - build-essential
+        - zlib1g-dev
+        - libextutils-cbuilder-perl
+        - libmodule-install-perl
+        - gettext
+        - asciidoc
+        - xmlto
+        - wget
+        - unzip
+        - make
+        - autoconf
+        - gcc

--- a/roles/common/tasks/prerequisites-redhat.yml
+++ b/roles/common/tasks/prerequisites-redhat.yml
@@ -1,18 +1,18 @@
 ---
 
 - name: Installing Red Hat family dependencies
-  yum: name={{ item }} state=present
-  with_items:
-      - kernel-debug-devel 
+  yum:
+      name:
+      - kernel-debug-devel
       - kernel-devel
-      - zlib-devel 
-      - perl-ExtUtils-CBuilder 
-      - perl-ExtUtils-MakeMaker 
+      - zlib-devel
+      - perl-ExtUtils-CBuilder
+      - perl-ExtUtils-MakeMaker
       - gettext
-      - asciidoc 
-      - xmlto 
+      - asciidoc
+      - xmlto
       - wget
       - unzip
       - make
       - autoconf
-      - gcc 
+      - gcc


### PR DESCRIPTION
Se ha comprobado con éxtito, aunque warnings de funciones deprecadas:

```
TASK [common : Installing Debian family dependencies] ***************************************************************************************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: ['build-essential', 'zlib1g-dev', 'libextutils-cbuilder-perl', 'libmodule-install-perl', 
'gettext', 'asciidoc', 'xmlto', 'wget', 'unzip', 'make', 'autoconf', 'gcc']` and remove the loop. This feature will be removed in version 2.11. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```